### PR TITLE
fix refresh session

### DIFF
--- a/CISCN-2018-web-for-players/checker/checker.py
+++ b/CISCN-2018-web-for-players/checker/checker.py
@@ -180,6 +180,7 @@ class WebChecker:
             except:
                 pass
             print '[+] Change Password Success'
+            self.session = newPass;
             return True
         print '[-] Change Password Failed'
         return False


### PR DESCRIPTION
检测密码修需要再次登陆，再次登陆后的session需要替换原来的session
原来的session由于检测密码修需要再次登陆而失效了